### PR TITLE
feat: allow auto-advancing when defaultValue present

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,11 +274,19 @@ export class SimpleSurvey extends Component {
                         `Default Selection not specified as an array for multiple selection question ${currentQuestionIndex}`
                     );
                 }
+
+                const hasDefaultValue = defaultSelection !== undefined;
                 const options = {};
                 options.maxMultiSelect = multiSelectMax;
                 options.allowDeselect = allowDeselect === undefined || allowDeselect === true;
-                options.defaultSelection = defaultSelection !== undefined ? defaultSelection : null;
+                options.defaultSelection = hasDefaultValue ? defaultSelection : null;
                 this.selectionHandlers[currentQuestionIndex] = new SelectionHandler(options);
+
+                if(hasDefaultValue && autoAdvanceThisQuestion) {
+                    setTimeout(() => {
+                        this.autoAdvance()
+                    }, 50);
+                }
 
                 if (Array.isArray(options.defaultSelection)) {
                     // Set timeout is used here to avoid updateAnswer's call to setState.

--- a/index.js
+++ b/index.js
@@ -177,11 +177,6 @@ export class SimpleSurvey extends Component {
                 `allowDeselect was not passed in as a boolean for question ${currentQuestionIndex}`
             );
         }
-        if (defaultSelection !== undefined && (this.props.autoAdvance || autoAdvanceThisQuestion)) {
-            throw new Error(
-                `Cannot set auto advance and a default selection for question ${currentQuestionIndex}`
-            );
-        }
         if (autoAdvanceThisQuestion !== undefined && 
             typeof autoAdvanceThisQuestion !== 'boolean') {
                 throw new Error(
@@ -207,11 +202,18 @@ export class SimpleSurvey extends Component {
                     );
                 }
 
+                const hasDefaultValue = defaultSelection !== undefined;
                 const options = {};
                 options.maxMultiSelect = 1;
                 options.allowDeselect = allowDeselect === undefined || allowDeselect === true;
-                options.defaultSelection = defaultSelection !== undefined ? defaultSelection : null;
-                
+                options.defaultSelection = hasDefaultValue ? defaultSelection : null;
+
+                if(hasDefaultValue && autoAdvanceThisQuestion) {
+                    setTimeout(() => {
+                        this.autoAdvance()
+                    }, 50);
+                }
+
                 this.selectionHandlers[currentQuestionIndex] = new SelectionHandler(options);
                 
                 if (typeof options.defaultSelection === 'number') { 


### PR DESCRIPTION
For my use case, my users may be returning to the app throughout the day to finish their survey. I'd rather not force them to click through each previously answered question, every time the page is rendered. Instead I'd like my users to be presented with the last unanswered question when they launch my app.

Probably the best solution is to add some property which would jump ahead to a specific page (defaultPage or defaultQuestionId for example).

This PR implements a really basic solution: autoAdvance is now allowed for questions with defaultValues, and a very slight delay of 50ms provides the visual of jumping forward in the survey.

Let me know if you'd me to improve this at all; happy to take a look at implementing a different solution if you have a suggestion.